### PR TITLE
standardize IndieAuth error handling

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -243,3 +243,42 @@ function get_indieauth_user_token( $key, $token, $hash = true ) {
 function set_indieauth_user_token( $id, $key, $token, $token_data ) {
 	return add_user_meta( $id, $key . $token, $token_data );
 }
+
+class WP_OAuth_Response extends WP_REST_Response {
+
+	public function __construct($error, $error_description, $code=200) {
+		$this->set_status($code);
+		$this->set_data( array(
+			'error' => $error,
+			'error_description' => $error_description
+		) );
+	}
+
+	public function set_debug($array) {
+		$data = $this->get_data();
+		$this->set_data( array_merge($data, $array) );
+	}
+
+}
+
+function get_oauth_error($obj) {
+	if ( is_array( $obj ) ) {
+		// When checking the result of wp_remote_post
+		if ( isset($obj['body']) ) {
+			$body = json_decode( $obj['body'], true );
+			if( isset( $body['error'] ) ) {
+				return new WP_OAuth_Response( 
+					$body['error'], 
+					isset($body['error_description']) ? $body['error_description'] : null,
+					$obj['response']['code']
+				);
+			}
+		}
+	} else if ( is_object( $obj ) && get_class($obj) == 'WP_OAuth_Response' ) {
+		$data = $obj->get_data();
+		if( isset( $data['error'] ) ) {
+			return $obj;
+		}
+	}
+	return false;
+}


### PR DESCRIPTION
* ensures all HTTP status codes are returned appropriately
* returns OAuth errors using `error` and `error_description` instead of WordPress style errors
* adds more detailed error messages at various parts of the workflow to help debugging later