### PR TITLE
fix whitespace in form elements

### DIFF
--- a/templates/indieauth-general-settings.php
+++ b/templates/indieauth-general-settings.php
@@ -6,20 +6,16 @@
 	</label>
 	<BR />
 	<label for="indieauth_authorization_endpoint">
-		<input type="text" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" size="60" value="
-		<?php
+		<input type="text" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" size="60" value="<?php
 			echo get_option( 'indieauth_authorization_endpoint' );
-			?>
-			" />
+			?>" />
 		<br /><?php _e( 'IndieAuth Authorization Endpoint.', 'indieauth' ); ?>
 	</label>
 	<BR />
 	<label for="indieauth_token_endpoint">
-		<input type="text" name="indieauth_token_endpoint" id="indieauth_token_endpoint" size=60" value="
-		<?php
+		<input type="text" name="indieauth_token_endpoint" id="indieauth_token_endpoint" size=60" value="<?php
 			echo get_option( 'indieauth_token_endpoint' );
-			?>
-			" />
+			?>" />
 		<br /><?php _e( 'IndieAuth Token Endpoint.', 'indieauth' ); ?>
 	</label>
 


### PR DESCRIPTION
with the `<?php` tags on the next line, it ends up including a bunch of whitespace in the values that are saved